### PR TITLE
Add xUnit tests

### DIFF
--- a/tests/Whelk.Tests/GlobalUsings.cs
+++ b/tests/Whelk.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/tests/Whelk.Tests/PasswordManagementTests.cs
+++ b/tests/Whelk.Tests/PasswordManagementTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using Microsoft.Research.SEAL;
+using Xunit;
+
+public class PasswordManagementTests
+{
+    private static void ResetDatabase()
+    {
+        var field = typeof(Program).GetField("passwordDatabase", BindingFlags.NonPublic | BindingFlags.Static);
+        var dict = (Dictionary<string, Ciphertext>)field.GetValue(null)!;
+        dict.Clear();
+    }
+
+    [Fact]
+    public void SetupEncryptionParameters_ReturnsExpectedSettings()
+    {
+        var parms = Program.SetupEncryptionParameters(out double scale);
+        Assert.Equal(8192u, parms.PolyModulusDegree);
+        Assert.Equal(Math.Pow(2.0, 40), scale);
+    }
+
+    [Fact]
+    public void EncodeEncryptDecrypt_RoundTripMaintainsData()
+    {
+        ResetDatabase();
+        var parms = Program.SetupEncryptionParameters(out double scale);
+        using var context = new SEALContext(parms);
+        var keys = Program.GenerateKeys(context);
+        var encoder = new CKKSEncoder(context);
+        var encryptor = new Encryptor(context, keys.PublicKey);
+        var decryptor = new Decryptor(context, keys.SecretKey);
+
+        List<double> pwd = new() {1,2,3,4,5};
+        var pt = Program.EncodePassword(encoder, pwd, scale);
+        var ct = Program.EncryptPassword(encryptor, pt);
+        var dpt = Program.DecryptPassword(decryptor, ct);
+        var decoded = Program.DecodePassword(encoder, dpt, pwd.Count);
+
+        Assert.Equal(pwd, decoded);
+    }
+
+    [Fact]
+    public void ValidatePassword_WorksForCorrectAndIncorrectPasswords()
+    {
+        ResetDatabase();
+        var parms = Program.SetupEncryptionParameters(out double scale);
+        using var context = new SEALContext(parms);
+        var keys = Program.GenerateKeys(context);
+        var encoder = new CKKSEncoder(context);
+        var encryptor = new Encryptor(context, keys.PublicKey);
+        var decryptor = new Decryptor(context, keys.SecretKey);
+
+        List<double> pwd = new() {1,2,3,4,5};
+        Program.StorePassword("user", pwd, encoder, encryptor, scale);
+
+        Assert.True(Program.ValidatePassword("user", pwd, encoder, encryptor, decryptor, scale));
+        var wrong = new List<double>{5,4,3,2,1};
+        Assert.False(Program.ValidatePassword("user", wrong, encoder, encryptor, decryptor, scale));
+    }
+
+    [Fact]
+    public void PasswordManagementExample2_PrintsExpectedResults()
+    {
+        ResetDatabase();
+        var parms = Program.SetupEncryptionParameters(out double scale);
+        using var context = new SEALContext(parms);
+        var keys = Program.GenerateKeys(context);
+        var encoder = new CKKSEncoder(context);
+        var encryptor = new Encryptor(context, keys.PublicKey);
+        var decryptor = new Decryptor(context, keys.SecretKey);
+        var evaluator = new Evaluator(context);
+
+        using var sw = new StringWriter();
+        Console.SetOut(sw);
+        Program.PasswordManagementExample2(encoder, encryptor, decryptor, evaluator, scale);
+        Console.Out.Flush();
+        var output = sw.ToString();
+        Console.SetOut(new StreamWriter(Console.OpenStandardOutput()) { AutoFlush = true });
+
+        Assert.Contains("Storing passwords...", output);
+        Assert.Contains("Validating passwords...", output);
+        Assert.Contains("Validation for user1 with correct password: True", output);
+        Assert.Contains("Validation for user2 with correct password: True", output);
+        Assert.Contains("Validation for user1 with incorrect password: False", output);
+    }
+}

--- a/tests/Whelk.Tests/Whelk.Tests.csproj
+++ b/tests/Whelk.Tests/Whelk.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <DefineConstants>EXCLUDE_MAIN</DefineConstants>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Research.SEALNet" Version="4.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\whelk\Program.cs" Link="Program.cs" />
+  </ItemGroup>
+
+</Project>

--- a/whelk.sln
+++ b/whelk.sln
@@ -5,6 +5,10 @@ VisualStudioVersion = 17.7.34024.191
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "whelk", "whelk\whelk.csproj", "{E8FDA1DD-6521-4754-A9BA-66ACE8E8341D}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{941A3F20-B930-4C5D-9AED-41314EADDDA4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Whelk.Tests", "tests\Whelk.Tests\Whelk.Tests.csproj", "{3FAA085D-1AD9-4487-B562-A521132700BB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,11 +25,22 @@ Global
 		{E8FDA1DD-6521-4754-A9BA-66ACE8E8341D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{E8FDA1DD-6521-4754-A9BA-66ACE8E8341D}.Release|x64.ActiveCfg = Release|x64
 		{E8FDA1DD-6521-4754-A9BA-66ACE8E8341D}.Release|x64.Build.0 = Release|x64
+		{3FAA085D-1AD9-4487-B562-A521132700BB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3FAA085D-1AD9-4487-B562-A521132700BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3FAA085D-1AD9-4487-B562-A521132700BB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3FAA085D-1AD9-4487-B562-A521132700BB}.Debug|x64.Build.0 = Debug|Any CPU
+		{3FAA085D-1AD9-4487-B562-A521132700BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3FAA085D-1AD9-4487-B562-A521132700BB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3FAA085D-1AD9-4487-B562-A521132700BB}.Release|x64.ActiveCfg = Release|Any CPU
+		{3FAA085D-1AD9-4487-B562-A521132700BB}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BB10CBFF-070C-4CE2-A027-2CE542E3F526}
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{3FAA085D-1AD9-4487-B562-A521132700BB} = {941A3F20-B930-4C5D-9AED-41314EADDDA4}
 	EndGlobalSection
 EndGlobal

--- a/whelk/Program.cs
+++ b/whelk/Program.cs
@@ -9,6 +9,7 @@ class Program
 {
     static Dictionary<string, Ciphertext> passwordDatabase = new Dictionary<string, Ciphertext>();
 
+#if !EXCLUDE_MAIN
     static void Main(string[] args)
     {
         Stopwatch stopwatch = Stopwatch.StartNew();
@@ -36,8 +37,9 @@ class Program
         Console.WriteLine($"Execution time: {stopwatch.ElapsedMilliseconds}ms");
         Console.ReadLine();
     }
+#endif
 
-    static EncryptionParameters SetupEncryptionParameters(out double scale)
+    internal static EncryptionParameters SetupEncryptionParameters(out double scale)
     {
         var parms = new EncryptionParameters(SchemeType.CKKS)
         {
@@ -48,7 +50,7 @@ class Program
         return parms;
     }
 
-    static (PublicKey PublicKey, SecretKey SecretKey) GenerateKeys(SEALContext context)
+    internal static (PublicKey PublicKey, SecretKey SecretKey) GenerateKeys(SEALContext context)
     {
         var keygen = new KeyGenerator(context);
         var secretKey = keygen.SecretKey;
@@ -56,40 +58,40 @@ class Program
         return (publicKey, secretKey);
     }
 
-    static Plaintext EncodePassword(CKKSEncoder encoder, List<double> plaintextPassword, double scale)
+    internal static Plaintext EncodePassword(CKKSEncoder encoder, List<double> plaintextPassword, double scale)
     {
         var plaintext = new Plaintext();
         encoder.Encode(plaintextPassword, scale, plaintext);
         return plaintext;
     }
 
-    static Ciphertext EncryptPassword(Encryptor encryptor, Plaintext plaintext)
+    internal static Ciphertext EncryptPassword(Encryptor encryptor, Plaintext plaintext)
     {
         var encryptedPassword = new Ciphertext();
         encryptor.Encrypt(plaintext, encryptedPassword);
         return encryptedPassword;
     }
 
-    static Plaintext DecryptPassword(Decryptor decryptor, Ciphertext encryptedPassword)
+    internal static Plaintext DecryptPassword(Decryptor decryptor, Ciphertext encryptedPassword)
     {
         var decryptedPassword = new Plaintext();
         decryptor.Decrypt(encryptedPassword, decryptedPassword);
         return decryptedPassword;
     }
 
-    static List<double> DecodePassword(CKKSEncoder encoder, Plaintext decryptedPassword, int count)
+    internal static List<double> DecodePassword(CKKSEncoder encoder, Plaintext decryptedPassword, int count)
     {
         var decodedPassword = new List<double>();
         encoder.Decode(decryptedPassword, decodedPassword);
         return decodedPassword.Take(count).Select(x => Math.Round(x)).ToList();
     }
 
-    static void StorePassword(string userId, List<double> plaintextPassword, CKKSEncoder encoder, Encryptor encryptor, double scale)
+    internal static void StorePassword(string userId, List<double> plaintextPassword, CKKSEncoder encoder, Encryptor encryptor, double scale)
     {
         passwordDatabase[userId] = EncryptPassword(encryptor, EncodePassword(encoder, plaintextPassword, scale));
     }
 
-    static bool ValidatePassword(string userId, List<double> inputPassword, CKKSEncoder encoder, Encryptor encryptor, Decryptor decryptor, double scale)
+    internal static bool ValidatePassword(string userId, List<double> inputPassword, CKKSEncoder encoder, Encryptor encryptor, Decryptor decryptor, double scale)
     {        
         if (!passwordDatabase.ContainsKey(userId)) 
             return false;
@@ -105,7 +107,7 @@ class Program
             DecodePassword(encoder, dp2, inputPassword.Count));
     }
 
-    static void PasswordManagementExample2(CKKSEncoder encoder, Encryptor encryptor, Decryptor decryptor, Evaluator evaluator, double scale)
+    internal static void PasswordManagementExample2(CKKSEncoder encoder, Encryptor encryptor, Decryptor decryptor, Evaluator evaluator, double scale)
     {
         List<double> password1 = new List<double> { 1, 2, 3, 4, 5, 67, 7, 8, 9, 10 };
         List<double> password2 = new List<double> { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
@@ -124,7 +126,7 @@ class Program
         Console.WriteLine($"Validation for user1 with incorrect password: {isInvalid}");
     }
 
-    static void PasswordManagementExample(CKKSEncoder encoder, Encryptor encryptor, Decryptor decryptor, Evaluator evaluator, double scale)
+    internal static void PasswordManagementExample(CKKSEncoder encoder, Encryptor encryptor, Decryptor decryptor, Evaluator evaluator, double scale)
     {
         List<double> plaintextPassword = new List<double>
         {


### PR DESCRIPTION
## Summary
- add an xUnit test project under `tests/`
- expose Program methods for testing and guard Main with `EXCLUDE_MAIN`
- link `Program.cs` into the test project
- exercise password helpers and example scenario
- include test project in `whelk.sln`

## Testing
- `dotnet test tests/Whelk.Tests/Whelk.Tests.csproj -v minimal`
- `dotnet build whelk/whelk.csproj` *(fails: reference assemblies for .NETFramework v4.7.2 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68404a3e0d7483289e6310c8be789fca