### PR TITLE
Add ClearPasswordDatabase

### DIFF
--- a/tests/Whelk.Tests/PasswordManagementTests.cs
+++ b/tests/Whelk.Tests/PasswordManagementTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
 using Microsoft.Research.SEAL;
 using Xunit;
 
@@ -9,9 +8,7 @@ public class PasswordManagementTests
 {
     private static void ResetDatabase()
     {
-        var field = typeof(Program).GetField("passwordDatabase", BindingFlags.NonPublic | BindingFlags.Static);
-        var dict = (Dictionary<string, Ciphertext>)field.GetValue(null)!;
-        dict.Clear();
+        Program.ClearPasswordDatabase();
     }
 
     [Fact]

--- a/whelk/Program.cs
+++ b/whelk/Program.cs
@@ -9,6 +9,11 @@ class Program
 {
     static Dictionary<string, Ciphertext> passwordDatabase = new Dictionary<string, Ciphertext>();
 
+    internal static void ClearPasswordDatabase()
+    {
+        passwordDatabase.Clear();
+    }
+
 #if !EXCLUDE_MAIN
     static void Main(string[] args)
     {


### PR DESCRIPTION
## Summary
- expose an internal helper to wipe the password DB
- simplify unit tests to use the new helper

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6840c2bd2dec8328936c7b413e40f54b